### PR TITLE
Add chromem-go to databases

### DIFF
--- a/llm-tools.md
+++ b/llm-tools.md
@@ -710,3 +710,4 @@ prompt templating / grammar / engineering:
 - [milvus](https://github.com/milvus-io/milvus) open-source cloud-native vector DB focusing on embedding vectors converted from unstructured data
 - [chroma](https://github.com/chroma-core/chroma) open-source embedding database
 - [pgvector](https://github.com/pgvector/pgvector) open-source vector similarity search for Postgres.
+- [chromem-go](https://github.com/philippgille/chromem-go) embeddable vector database for Go with Chroma-like interface and zero third-party dependencies. In-memory with optional persistence. 


### PR DESCRIPTION
Hi 👋 , thanks for creating and maintaining this overview! I've been working on [chromem-go](https://github.com/philippgille/chromem-go), which differs from most other vector databases in that it's embeddable in Go (no client-server model, no CGO). I'd be very happy if it can be added to this awesome list!