### PR TITLE
Add MLflow to llm-tools.md

### DIFF
--- a/llm-tools.md
+++ b/llm-tools.md
@@ -854,6 +854,7 @@
 - [skypilot](https://github.com/skypilot-org/skypilot) Run LLMs, AI, and Batch jobs on any cloud. Get maximum savings, highest GPU availability, and managed execution
 - [ONNX Runtime](https://github.com/microsoft/onnxruntime) cross-platform inference and training machine-learning accelerator compatible with PyTorch, TensorFlow/Keras, scikit-learn, LightGBM, XGBoost, etc. and runs with different hardware, drivers, and operating systems
 - [vllm](https://github.com/vllm-project/vllm) high-throughput and memory-efficient inference and serving engine for LLMs, [paper](https://arxiv.org/pdf/2309.06180v1.pdf)
+- [MLflow](https://github.com/mlflow/mlflow) An open-source framework for the end-to-end machine learning lifecycle, helping developers track experiments, evaluate models/prompts, deploy models, and add observability with tracing.
 - [openllmetry](https://github.com/traceloop/openllmetry) observability for your LLM application, based on OpenTelemetry
 - [DeepSpeed-FastGen](https://github.com/microsoft/DeepSpeed/tree/master/blogs/deepspeed-fastgen) High-throughput Text Generation for LLMs at 2x vLLM speeds
 - [DeepSparse](https://github.com/neuralmagic/deepsparse) Sparsity-aware deep learning inference runtime for CPUs


### PR DESCRIPTION
I would like to add [MLflow](https://mlflow.org/) to the "AI DevOps" category, as it provides various LLMOps capabilities (prompt tracking, evaluation, tracing, and more) and has been adapted by many people (19K stars).