### PR TITLE
Add What LLM Can I Run to Open LLM Models

### DIFF
--- a/llm-tools.md
+++ b/llm-tools.md
@@ -5,6 +5,7 @@
 - Want to know which one is "the best"? Have a look at the [🏆 Leaderboards](llm-tools.md#benchmarking) in the Benchmarking section.
 - [llm.extractum.io](https://llm.extractum.io/) The LLM Explorer, a Large Language Model Directory with filters for trending, downloads and latest showing details like quantizations, model types and sizes
 - [can-it-run-llm](https://huggingface.co/spaces/Vokturz/can-it-run-llm) Check most Huggingface LLMs and quants for hardware requirements like vram, ram and memory requirements
+- [What LLM Can I Run?](https://whatsmy.fyi/what-llm-can-i-run) Detects your hardware live in the browser and checks it against 41 open-weight models, showing per-quantization sizes, minimum RAM and tok/s estimates
 
 # Tools
 

--- a/llm-tools.md
+++ b/llm-tools.md
@@ -5,7 +5,7 @@
 - Want to know which one is "the best"? Have a look at the [🏆 Leaderboards](llm-tools.md#benchmarking) in the Benchmarking section.
 - [llm.extractum.io](https://llm.extractum.io/) The LLM Explorer, a Large Language Model Directory with filters for trending, downloads and latest showing details like quantizations, model types and sizes
 - [can-it-run-llm](https://huggingface.co/spaces/Vokturz/can-it-run-llm) Check most Huggingface LLMs and quants for hardware requirements like vram, ram and memory requirements
-- [What LLM Can I Run?](https://whatsmy.fyi/what-llm-can-i-run) Detects your hardware live in the browser and checks it against 41 open-weight models, showing per-quantization sizes, minimum RAM and tok/s estimates
+- [What LLM Can I Run?](https://whatsmy.fyi/what-llm-can-i-run) Detects your hardware live in the browser and checks it against 70+ open-weight models, showing per-quantization sizes, minimum RAM and tok/s estimates
 
 # Tools
 


### PR DESCRIPTION
## What this adds
[What LLM Can I Run?](https://whatsmy.fyi/what-llm-can-i-run) — a free, in-browser hardware
checker, added to Open LLM Models next to the similar can-it-run-llm entry.

## Why it fits
- Same purpose as can-it-run-llm, but detects the visitor's hardware live via WebGPU
  (incl. an optional memory-bandwidth benchmark) instead of manual input
- Covers 70+ open-weight models: per-quantization sizes, min RAM, KV-cache-by-context
  and tok/s estimates per GPU class
- Methodology fully published: https://whatsmy.fyi/what-llm-can-i-run/methodology
- Free, no signup, zero data stored (runs entirely client-side)

Formatting matches the surrounding entries. Happy to adjust wording or placement.